### PR TITLE
Some changes around BSON::Document handling

### DIFF
--- a/lib/mongoid_money_field/field.rb
+++ b/lib/mongoid_money_field/field.rb
@@ -15,7 +15,10 @@ class Money
     # Get the object as it was stored in the database, and instantiate
     # this custom class from it.
     def demongoize(object)
-      if object.is_a?(Hash)
+      case
+      when object.is_a?(BSON::Document) then
+        object.has_key?(:cents) ? ::Money.new(object[:cents], object[:currency_iso]) : nil
+      when object.is_a?(Hash) then
         object = object.symbolize_keys
         object.has_key?(:cents) ? ::Money.new(object[:cents], object[:currency_iso]) : nil
       else
@@ -28,6 +31,8 @@ class Money
     def mongoize(object)
       case
         when object.is_a?(Money) then object.mongoize
+        when object.is_a?(BSON::Document) then
+          ::Money.new(object[:cents], object[:currency_iso]).mongoize
         when object.is_a?(Hash) then
           object.symbolize_keys! if object.respond_to?(:symbolize_keys!)
           ::Money.new(object[:cents], object[:currency_iso]).mongoize

--- a/lib/mongoid_money_field/type.rb
+++ b/lib/mongoid_money_field/type.rb
@@ -49,6 +49,8 @@ class MoneyType
 
       ret = case
         when object.is_a?(Money) then object.mongoize
+        when object.is_a?(BSON::Document)
+          ::Money.new(object[:cents], object[:currency_iso]).mongoize
         when object.is_a?(Hash) then
           object.symbolize_keys! if object.respond_to?(:symbolize_keys!)
           ::Money.new(object[:cents], object[:currency_iso]).mongoize

--- a/mongoid_money_field.gemspec
+++ b/mongoid_money_field.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mongoid", "~> 7.0"
+  spec.add_runtime_dependency "mongoid", "~> 8.0"
   spec.add_runtime_dependency "money", "~> 6.13.2"
   spec.add_runtime_dependency "monetize"
 

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+describe Money do
+  context '#demongoize' do
+    it "doesn't use symbolize_keys on BSON::Document" do
+      doc1 = BSON::Document.new(cents: 1234, currency_iso: 'USD')
+      doc2 = BSON::Document.new('cents' => 1234, 'currency_iso' => 'USD')
+
+      expect(doc1).not_to receive(:symbolize_keys)
+      expect(doc2).not_to receive(:symbolize_keys)
+
+      expect(described_class.demongoize(doc1)).to eq(Money.new(1234, 'USD'))
+      expect(described_class.demongoize(doc2)).to eq(Money.new(1234, 'USD'))
+    end
+  end
+
+  context '#mongoize' do
+    it "doesn't fail with BSON::Document on newer versions of bson gem" do
+      doc1 = BSON::Document.new(cents: 1234, currency_iso: 'USD')
+      doc2 = BSON::Document.new('cents' => 1234, 'currency_iso' => 'USD')
+
+      allow(doc1).to receive(:symbolize_keys!).and_raise(
+        ArgumentError, "symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #symbolize_keys! on the Hash instance"
+      )
+
+      allow(doc2).to receive(:symbolize_keys!).and_raise(
+        ArgumentError, "symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #symbolize_keys! on the Hash instance"
+      )
+
+      expect(described_class.mongoize(doc1)).to eq({cents: 1234, currency_iso: 'USD'})
+      expect(described_class.mongoize(doc2)).to eq({cents: 1234, currency_iso: 'USD'})
+    end
+  end
+end

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+describe MoneyType do
+  context '#mongoize' do
+    it "doesn't fail with BSON::Document on newer versions of bson gem" do
+      doc = BSON::Document.new(cents: 1234, currency_iso: 'USD')
+
+      allow(doc).to receive(:symbolize_keys!).and_raise(
+        ArgumentError, "symbolize_keys! is not supported on BSON::Document instances. Please convert the document to hash first (using #to_h), then call #symbolize_keys! on the Hash instance"
+      )
+
+      expect(subject.mongoize(doc)).to eq({cents: 1234, currency_iso: 'USD'})
+    end
+  end
+end


### PR DESCRIPTION
- `BSON::Document#symbolize_keys!` raises an error in newer versions of BSON gem 
https://github.com/mongodb/bson-ruby/blame/520606c590c562e9b03d8b275f4e32604a1ccfdc/lib/bson/document.rb#L320

We can handle `BSON::Document` more efficiently by not symbolizing keys, because it already handles string/symbol key conversion internally - also updated this in a few other places